### PR TITLE
Update LICENSE to have PromptWorks as copyright holder

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Cisco Systems, Inc.
+Copyright (c) 2017 PromptWorks, LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
I noticed the same thing was happening for the jira and doorman bots, so figured it's appropriate here as well.